### PR TITLE
Add listener count to avoid emitter leak warning

### DIFF
--- a/src/write.js
+++ b/src/write.js
@@ -25,6 +25,7 @@ module.exports = (RED) => {
       }
     };
 
+    this.serverConfig.setMaxListeners(this.serverConfig.getMaxListeners() + 1);
     this.serverConfig.on('stateWrite', (code, info) => this.setState(code, info));
 
     this.on('input', async msg => {


### PR DESCRIPTION
When multiple write nodes are placed in one flow the logs show a warning of the kind:

> (node:31) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 stateWrite listeners added to [InfluxDbV2Node]. Use emitter.setMaxListeners() to increase limit

This one-liner increases the maximum number of listeners right before the listener is hooked up and thus no warning is generated.